### PR TITLE
Utilize PAT for autoreleaser

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -19,4 +19,4 @@ jobs:
     name: Auto Releaser
     uses: lockerstock/github-actions/.github/workflows/reusable-changelog.yaml@main
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN  }}
+      token: ${{ secrets.GHA_ACCESS_TOKEN  }}


### PR DESCRIPTION
# Overview
After merging #3, I found that the tagged release made did not kick off the GH Pages Publisher action. I vaguely remember that the default token cannot be used in branch/tag creation and be able to kick off other github actions. This was setup to prevent accidental infinite loops of github actions.

I created a custom fine-grained PAT with a content-writing scope.

> I also deleted the `v0.3.0` release and tag so when this merges it can attempt the same release again.